### PR TITLE
fix crash on Android 12

### DIFF
--- a/bestlocationstrategy/build.gradle
+++ b/bestlocationstrategy/build.gradle
@@ -40,7 +40,7 @@ android {
 dependencies {
     implementation 'com.google.android.gms:play-services-location:17.1.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.21'
-    implementation 'androidx.work:work-runtime:2.0.1'
+    implementation 'androidx.work:work-runtime:2.7.1'
 }
 task comps {
     afterEvaluate {

--- a/bestlocationstrategy/src/main/java/com/location/bestlocationstrategy/GooglePlayServiceLocationStrategy.kt
+++ b/bestlocationstrategy/src/main/java/com/location/bestlocationstrategy/GooglePlayServiceLocationStrategy.kt
@@ -393,7 +393,7 @@ internal class GooglePlayServiceLocationStrategy(
         mLocationCallback?.let {
             mFusedLocationClient?.removeLocationUpdates(mLocationCallback)
         }
-        WorkManager.getInstance().cancelAllWorkByTag(TAG);
+        WorkManager.getInstance(mAppContext).cancelAllWorkByTag(TAG);
 
     }
 

--- a/bestlocationstrategy/src/main/java/com/location/bestlocationstrategy/foregroundservice/ForegroundOnlyLocationService.kt
+++ b/bestlocationstrategy/src/main/java/com/location/bestlocationstrategy/foregroundservice/ForegroundOnlyLocationService.kt
@@ -111,7 +111,7 @@ class ForegroundOnlyLocationService : Service() {
                     PeriodicWorkRequest.Builder(MyWorker::class.java, 15, TimeUnit.MINUTES)
                         .addTag(TAG)
                         .build()
-                WorkManager.getInstance().enqueueUniquePeriodicWork(
+                WorkManager.getInstance(this).enqueueUniquePeriodicWork(
                     Companion.TAG,
                     ExistingPeriodicWorkPolicy.REPLACE,
                     periodicWork
@@ -214,7 +214,7 @@ class ForegroundOnlyLocationService : Service() {
         cancelIntent.putExtra(EXTRA_CANCEL_LOCATION_TRACKING_FROM_NOTIFICATION, true)
 
         val servicePendingIntent = PendingIntent.getService(
-            this, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT
+            this, 0, cancelIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
 //        val activityPendingIntent = PendingIntent.getActivity(


### PR DESCRIPTION
When using this library in an app on a device with >= Android 12 the app crashes with following stack trace:

```
E/AndroidRuntime: FATAL EXCEPTION: WorkManager-WorkManagerTaskExecutor-thread-0
    Process: myapp, PID: 6954
    java.lang.IllegalArgumentException: myapp: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:401)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:671)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:658)
        at androidx.work.impl.utils.ForceStopRunnable.getPendingIntent(ForceStopRunnable.java:147)
        at androidx.work.impl.utils.ForceStopRunnable.isForceStopped(ForceStopRunnable.java:124)
        at androidx.work.impl.utils.ForceStopRunnable.run(ForceStopRunnable.java:79)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
        at java.lang.Thread.run(Thread.java:1012)
```

This ultimately has two causes:

1. Inside `ForegroundOnlyLocationService` a `PendingIntent` is created, missing this flag.
2. This project references the library `androidx.work:work-runtime:2.0.1`. There was a bug which was only fixed in [2.7.0-alpha02](https://developer.android.com/jetpack/androidx/releases/work#2.7.0-alpha02):
   
   > Make `PendingIntent` mutability explicit, to fix a crash when targeting Android 12.
  
   This pull request updates the library to the latest version.